### PR TITLE
Slice buffer if read bytes count is less than requested length

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ module.exports = function (filepath, pos, len, cb) {
 					return cb(err);
 				}
 
+				if (bytesRead < len) {
+					buf = buf.slice(0, bytesRead);
+				}
+
 				cb(null, buf);
 			});
 		});
@@ -28,7 +32,12 @@ module.exports = function (filepath, pos, len, cb) {
 module.exports.sync = function (filepath, pos, len) {
 	var buf = new Buffer(len);
 	var fd = fs.openSync(filepath, 'r');
-	fs.readSync(fd, buf, 0, len, pos);
+	var bytesRead = fs.readSync(fd, buf, 0, len, pos);
 	fs.closeSync(fd);
+
+	if (bytesRead < len) {
+		buf = buf.slice(0, bytesRead);
+	}
+
 	return buf;
 };

--- a/test.js
+++ b/test.js
@@ -9,10 +9,21 @@ describe('readChunk()', function () {
 			cb();
 		});
 	});
+
+	it('should slice buffer if read bytes count is less than requested length', function (cb) {
+		readChunk('fixture', 0, 15, function (err, buf) {
+			assert.equal(buf.toString(), 'hello\n');
+			cb();
+		});
+	});
 });
 
 describe('readChunk.sync()', function () {
 	it('should read chunks from a file', function () {
 		assert.equal(readChunk.sync('fixture', 1, 4).toString(), 'ello');
+	});
+
+	it('should slice buffer if read bytes count is less than requested length', function () {
+		assert.equal(readChunk.sync('fixture', 0, 15).toString(), 'hello\n');
 	});
 });


### PR DESCRIPTION
If length is bigger than actual read file, returned buffer should be sliced.