### PR TITLE
Use Buffer.alloc if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
 'use strict';
 const fs = require('fs');
 const pify = require('pify');
+
 const fsP = pify(fs);
 const fsReadP = pify(fs.read, {multiArgs: true});
 
+function createBuffer(len) {
+	if (Buffer.alloc) {
+		return Buffer.alloc(len);
+	}
+
+	// TODO: remove when when Node.js 6 is target (needed for Node.js < 5.10.0)
+	return new Buffer(len);
+}
+
 module.exports = (filepath, pos, len) => {
-	const buf = new Buffer(len);
+	const buf = createBuffer(len);
 
 	return fsP.open(filepath, 'r')
 		.then(fd =>
@@ -27,7 +37,7 @@ module.exports = (filepath, pos, len) => {
 };
 
 module.exports.sync = (filepath, pos, len) => {
-	let buf = new Buffer(len);
+	let buf = createBuffer(len);
 
 	const fd = fs.openSync(filepath, 'r');
 	const bytesRead = fs.readSync(fd, buf, 0, len, pos);

--- a/index.js
+++ b/index.js
@@ -5,17 +5,8 @@ const pify = require('pify');
 const fsP = pify(fs);
 const fsReadP = pify(fs.read, {multiArgs: true});
 
-function createBuffer(len) {
-	if (Buffer.alloc) {
-		return Buffer.alloc(len);
-	}
-
-	// TODO: remove when when Node.js 6 is target (needed for Node.js < 5.10.0)
-	return new Buffer(len);
-}
-
 module.exports = (filepath, pos, len) => {
-	const buf = createBuffer(len);
+	const buf = Buffer.alloc(len);
 
 	return fsP.open(filepath, 'r')
 		.then(fd =>
@@ -37,7 +28,7 @@ module.exports = (filepath, pos, len) => {
 };
 
 module.exports.sync = (filepath, pos, len) => {
-	let buf = createBuffer(len);
+	let buf = Buffer.alloc(len);
 
 	const fd = fs.openSync(filepath, 'r');
 	const bytesRead = fs.readSync(fd, buf, 0, len, pos);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "xo": "*"
   },
   "xo": {
-    "esnext": true
+    "esnext": true,
+    "rules": {
+      "unicorn/no-new-buffer": "warn"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "xo": "*"
   },
   "xo": {
-    "esnext": true,
-    "rules": {
-      "unicorn/no-new-buffer": "warn"
-    }
+    "esnext": true
   }
 }


### PR DESCRIPTION
This is the now recommended method to create new Buffer instances with fixed size. It will not be prefilled with random, potentially sensitive data, but will be zero-filled.
Downside: `alloc` may be significantly slower than `new Buffer`.

This fixes #6 

~If Node.js versions < `5.10.0` are no longer to be targeted, the old Buffer initialisation can be removed completely.~ (supported even in Node.js 4, see comments below)