### PR TITLE
Fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import Buffer from 'node:buffer';
+import {Buffer} from 'node:buffer';
 
 export interface Options {
 	/**


### PR DESCRIPTION
Fix for issue with following configuration:
read-chunk: 4.0.1
Node.js version: 14.17.6
Typescript version: 4.4.2

When trying to build project with read-chunk installed, the following error occured:
![image](https://user-images.githubusercontent.com/32069491/131861038-f58f6271-5a36-4d41-82dd-84bc97dfdab1.png)

The fix in this PR is to add brackets around the import for the Buffer module to do a named import instead. 

Runned the unit test in the project and they still pass as before.