### PR TITLE
chore: update github workflow to use node v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
+          - 20
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
I noticed some warnings in the test runs, would be nice to update them to the latest LTS version of node.