### PR TITLE
breaking: drop pify dependency and make node v16 the minimum version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         node-version:
           - 20
+          - 18
+          - 16
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.js
+++ b/index.js
@@ -1,16 +1,11 @@
-import {promisify} from 'node:util';
-import fs from 'node:fs';
-import pify from 'pify';
-
-const fsReadP = pify(fs.read, {multiArgs: true});
-const fsOpenP = promisify(fs.open);
-const fsCloseP = promisify(fs.close);
+import {closeSync, openSync, readSync} from 'node:fs';
+import {open} from 'node:fs/promises';
 
 export async function readChunk(filePath, {length, startPosition}) {
-	const fileDescriptor = await fsOpenP(filePath, 'r');
+	const fileDescriptor = await open(filePath, 'r');
 
 	try {
-		let [bytesRead, buffer] = await fsReadP(fileDescriptor, {
+		let {bytesRead, buffer} = await fileDescriptor.read({
 			buffer: new Uint8Array(length),
 			length,
 			position: startPosition,
@@ -22,16 +17,16 @@ export async function readChunk(filePath, {length, startPosition}) {
 
 		return buffer;
 	} finally {
-		await fsCloseP(fileDescriptor);
+		await fileDescriptor?.close();
 	}
 }
 
 export function readChunkSync(filePath, {length, startPosition}) {
 	let buffer = new Uint8Array(length);
-	const fileDescriptor = fs.openSync(filePath, 'r');
+	const fileDescriptor = openSync(filePath, 'r');
 
 	try {
-		const bytesRead = fs.readSync(fileDescriptor, buffer, {
+		const bytesRead = readSync(fileDescriptor, buffer, {
 			length,
 			position: startPosition,
 		});
@@ -42,6 +37,6 @@ export function readChunkSync(filePath, {length, startPosition}) {
 
 		return buffer;
 	} finally {
-		fs.closeSync(fileDescriptor);
+		closeSync(fileDescriptor);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": ">=16.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -36,9 +36,6 @@
 		"fd",
 		"open"
 	],
-	"dependencies": {
-		"pify": "^5.0.0"
-	},
 	"devDependencies": {
 		"@types/node": "^16.4.13",
 		"ava": "^6.1.3",


### PR DESCRIPTION
`fs/promises` has been available for quite some time so we can use that and remove `pify` as a dependency.

Since we added `uint8array-extras` as a devDependency and it uses nullish coalescing we can only test on node v16 and higher.

Might as well set that as the minimum version since that's what we can test.

I'm done making changes to this library after this PR, it's ready for a major version bump and a release 👍